### PR TITLE
Variants expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "strapi": "strapi"
   },
   "dependencies": {
-    "@strapi/plugin-graphql": "^4.2.0",
-    "@strapi/plugin-i18n": "4.2.0",
-    "@strapi/plugin-users-permissions": "4.2.0",
-    "@strapi/provider-upload-cloudinary": "^4.2.0",
-    "@strapi/strapi": "4.2.0",
+    "@strapi/plugin-graphql": "^4.3.6",
+    "@strapi/plugin-i18n": "4.3.6",
+    "@strapi/plugin-users-permissions": "4.3.6",
+    "@strapi/provider-upload-cloudinary": "^4.3.6",
+    "@strapi/strapi": "4.3.6",
     "better-sqlite3": "7.4.6",
     "pg": "^8.7.3",
     "pg-connection-string": "^2.5.0"

--- a/src/api/product/content-types/product/schema.json
+++ b/src/api/product/content-types/product/schema.json
@@ -85,6 +85,11 @@
       "repeatable": false,
       "component": "seo.seo",
       "required": false
+    },
+    "variants": {
+      "type": "component",
+      "repeatable": true,
+      "component": "variants.variant-group"
     }
   }
 }

--- a/src/api/product/content-types/product/schema.json
+++ b/src/api/product/content-types/product/schema.json
@@ -53,7 +53,7 @@
       "required": true,
       "min": 0
     },
-    "inventory": {
+    "quantity": {
       "type": "integer",
       "required": true,
       "min": 1

--- a/src/api/product/content-types/product/schema.json
+++ b/src/api/product/content-types/product/schema.json
@@ -47,7 +47,7 @@
     "quantity": {
       "type": "integer",
       "required": true,
-      "min": 1
+      "min": 0
     },
     "sellWithoutStock": {
       "type": "boolean",

--- a/src/api/product/content-types/product/schema.json
+++ b/src/api/product/content-types/product/schema.json
@@ -22,21 +22,8 @@
       "targetField": "title",
       "required": true
     },
-    "sku": {
-      "type": "uid",
-      "required": true
-    },
     "description": {
       "type": "richtext"
-    },
-    "media": {
-      "type": "media",
-      "multiple": true,
-      "required": true,
-      "allowedTypes": [
-        "images"
-      ],
-      "pluginOptions": {}
     },
     "price": {
       "type": "float",
@@ -53,6 +40,10 @@
       "required": true,
       "min": 0
     },
+    "sku": {
+      "type": "uid",
+      "required": true
+    },
     "quantity": {
       "type": "integer",
       "required": true,
@@ -61,6 +52,27 @@
     "sellWithoutStock": {
       "type": "boolean",
       "default": false,
+      "required": false
+    },
+    "media": {
+      "type": "media",
+      "multiple": true,
+      "required": true,
+      "allowedTypes": [
+        "images"
+      ],
+      "pluginOptions": {}
+    },
+    "variants": {
+      "type": "component",
+      "repeatable": true,
+      "component": "variants.variant-group"
+    },
+    "seoInformation": {
+      "displayName": "SEO",
+      "type": "component",
+      "repeatable": false,
+      "component": "seo.seo",
       "required": false
     },
     "productType": {
@@ -78,18 +90,6 @@
       "relation": "manyToMany",
       "target": "api::collection.collection",
       "mappedBy": "products"
-    },
-    "seoInformation": {
-      "displayName": "SEO",
-      "type": "component",
-      "repeatable": false,
-      "component": "seo.seo",
-      "required": false
-    },
-    "variants": {
-      "type": "component",
-      "repeatable": true,
-      "component": "variants.variant-group"
     }
   }
 }

--- a/src/api/product/content-types/product/schema.json
+++ b/src/api/product/content-types/product/schema.json
@@ -22,6 +22,10 @@
       "targetField": "title",
       "required": true
     },
+    "sku": {
+      "type": "uid",
+      "required": true
+    },
     "description": {
       "type": "richtext"
     },

--- a/src/components/variants/variant-group.json
+++ b/src/components/variants/variant-group.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_variants_variant_groups",
+  "info": {
+    "displayName": "Variant Group",
+    "icon": "arrows-alt"
+  },
+  "options": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "Option": {
+      "displayName": "Variant",
+      "type": "component",
+      "repeatable": true,
+      "component": "variants.variant",
+      "required": true,
+      "min": 1
+    }
+  }
+}

--- a/src/components/variants/variant.json
+++ b/src/components/variants/variant.json
@@ -1,0 +1,47 @@
+{
+  "collectionName": "components_variants_variants",
+  "info": {
+    "displayName": "Variant",
+    "icon": "cart-arrow-down",
+    "description": ""
+  },
+  "options": {},
+  "attributes": {
+    "variant": {
+      "type": "string",
+      "required": true
+    },
+    "price": {
+      "type": "float",
+      "required": true,
+      "min": 0
+    },
+    "costPerItem": {
+      "type": "float",
+      "required": true,
+      "min": 0
+    },
+    "compareAtPrice": {
+      "type": "float",
+      "required": true,
+      "min": 0
+    },
+    "sku": {
+      "type": "string",
+      "required": true
+    },
+    "inventory": {
+      "type": "integer",
+      "required": true,
+      "min": 0
+    },
+    "media": {
+      "type": "media",
+      "multiple": true,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    }
+  }
+}

--- a/src/components/variants/variant.json
+++ b/src/components/variants/variant.json
@@ -30,7 +30,7 @@
       "type": "string",
       "required": true
     },
-    "inventory": {
+    "quantity": {
       "type": "integer",
       "required": true,
       "min": 0

--- a/src/components/variants/variant.json
+++ b/src/components/variants/variant.json
@@ -23,7 +23,7 @@
     },
     "compareAtPrice": {
       "type": "float",
-      "required": true,
+      "required": false,
       "min": 0
     },
     "sku": {

--- a/src/components/variants/variant.json
+++ b/src/components/variants/variant.json
@@ -37,7 +37,7 @@
     },
     "media": {
       "type": "media",
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "allowedTypes": [
         "images"


### PR DESCRIPTION
Strapi has been updated from v4.2.0 to v4.3.6.

Added SKU fields for better inventory tracking.
Changed `inventory` items to `quantity`,
Minor changes to the required status of certain fields and their requirements (e. g. minimum amount).

Users can now create variant groups and their correspondent options, which include the following fields:
- Variant
- Price
- Cost per item
- Compare at price
- SKU
- Quantity
- Media